### PR TITLE
remove string fields, telegraf counts them as syntax error??

### DIFF
--- a/syncthing_stats.go
+++ b/syncthing_stats.go
@@ -122,7 +122,7 @@ func handleSystemConnections(apiKey string, wg *sync.WaitGroup) error {
 			if connectionStat.Connected {
 				connected = 1
 			}
-			fmt.Printf("syncthing_connection,client_id=%s connected=%d,paused=%d,in_bytes=%d,out_bytes=%d,type=%s\n", connectionId, connected, paused, connectionStat.InBytesTotal, connectionStat.OutBytesTotal, connectionStat.Type)
+			fmt.Printf("syncthing_connection,client_id=%s connected=%d,paused=%d,in_bytes=%d,out_bytes=%d\n", connectionId, connected, paused, connectionStat.InBytesTotal, connectionStat.OutBytesTotal)
 		}
 	}
 	return nil
@@ -141,7 +141,7 @@ func handleFolderStats(apiKey string, folderConfig FolderConfig, wg *sync.WaitGr
 		os.Stderr.Write([]byte(fmt.Sprintf("invalid response body: %s", err)))
 		return
 	}
-	fmt.Printf("syncthing_folder,folder_id=%s type=%s,rescanInterval=%d,errors=%d,global_bytes=%d,global_deleted=%d,global_directories=%d,global_files=%d,global_symlinks=%d,global_total_items=%d,insync_bytes=%d,insync_files=%d,local_bytes=%d,local_deleted=%d,local_directories=%d,local_files=%d,local_symlinks=%d,local_total_items=%d,need_bytes=%d,need_deletes=%d,need_directories=%d,need_files=%d,need_symlinks=%d,need_total_items=%d,pull_errors=%d\n", folderConfig.ID, folderConfig.Type, folderConfig.RescanIntervalS, stats.Errors, stats.GlobalBytes, stats.GlobalDeleted, stats.GlobalDirectories, stats.GlobalFiles, stats.GlobalSymlinks, stats.GlobalTotalItems, stats.InSyncBytes, stats.InSyncFiles, stats.LocalBytes, stats.LocalDeleted, stats.LocalDirectories, stats.LocalFiles, stats.LocalSymlinks, stats.LocalTotalItems, stats.NeedBytes, stats.NeedDeletes, stats.NeedDirectories, stats.NeedFiles, stats.NeedSymlinks, stats.NeedTotalItems, stats.PullErrors)
+	fmt.Printf("syncthing_folder,folder_id=%s rescanInterval=%d,errors=%d,global_bytes=%d,global_deleted=%d,global_directories=%d,global_files=%d,global_symlinks=%d,global_total_items=%d,insync_bytes=%d,insync_files=%d,local_bytes=%d,local_deleted=%d,local_directories=%d,local_files=%d,local_symlinks=%d,local_total_items=%d,need_bytes=%d,need_deletes=%d,need_directories=%d,need_files=%d,need_symlinks=%d,need_total_items=%d,pull_errors=%d\n", folderConfig.ID, folderConfig.RescanIntervalS, stats.Errors, stats.GlobalBytes, stats.GlobalDeleted, stats.GlobalDirectories, stats.GlobalFiles, stats.GlobalSymlinks, stats.GlobalTotalItems, stats.InSyncBytes, stats.InSyncFiles, stats.LocalBytes, stats.LocalDeleted, stats.LocalDirectories, stats.LocalFiles, stats.LocalSymlinks, stats.LocalTotalItems, stats.NeedBytes, stats.NeedDeletes, stats.NeedDirectories, stats.NeedFiles, stats.NeedSymlinks, stats.NeedTotalItems, stats.PullErrors)
 }
 
 func handleFolders(apiKey string, wg *sync.WaitGroup) error {


### PR DESCRIPTION
Using the code as-is, telegraf reports a syntax error, and throws away all of the data. After removing the string fields, everything else works fine. I'm not sure if string fields are actually supported and we're just using the wrong syntax, but I wasn't interested in those so removing them was the easiest way to get things working :)